### PR TITLE
macOS: add a tarball fallback to INSTALL.sh

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -764,6 +764,18 @@ jobs:
           name: packages.brew.${{ inputs.ref }}
           path: opentelemetry-shell_*.tar.gz
           if-no-files-found: error
+      # fill in the formula's version/sha256 placeholders so it's ready to drop into a homebrew
+      # tap; publishing it to an actual `plengauer/homebrew-opentelemetry-shell` tap repository on
+      # release is a separate, not-yet-automated step
+      - run: |
+          version="$(cat VERSION)"
+          sha256="$(sha256sum opentelemetry-shell_"$version".tar.gz | cut -d ' ' -f 1)"
+          sed "s/__VERSION__/$version/g; s/__SHA256__/$sha256/g" meta/homebrew/opentelemetry-shell.rb > opentelemetry-shell.rb
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: homebrew-formula.${{ inputs.ref }}
+          path: opentelemetry-shell.rb
+          if-no-files-found: error
 
   build-workflow-image:
     needs: build-apk

--- a/.github/workflows/test_shell.yml
+++ b/.github/workflows/test_shell.yml
@@ -33,11 +33,14 @@ jobs:
       - if: runner.os == 'macOS'
         run: |
           brew install jq wget curl bash coreutils findutils grep gnu-sed gawk
-          # /usr is on the SIP-sealed system volume on modern macOS, so the package has to live under
-          # /usr/local instead; --strip-components=2 turns the tarball's usr/bin, usr/share/... into
-          # bin/..., share/... so they land directly at /usr/local/bin, /usr/local/share/opentelemetry_shell
+          # /usr is on the SIP-sealed system volume on modern macOS, so the usr subtree has to live
+          # under /usr/local instead; --strip-components=2 turns the tarball's usr/bin, usr/share/...
+          # into bin/..., share/... so they land at /usr/local/bin, /usr/local/share/opentelemetry_shell.
+          # /opt is not sealed, so the opt subtree keeps its normal location (api.sh and the pip
+          # install below both expect the SDK venv and requirements at /opt/opentelemetry_shell).
           sudo mkdir -p /usr/local/bin /usr/local/share
-          sudo tar --strip-components=2 -xzf opentelemetry-shell_*.tar.gz -C /usr/local
+          sudo tar --strip-components=2 -xzf opentelemetry-shell_*.tar.gz -C /usr/local usr
+          sudo tar --strip-components=1 -xzf opentelemetry-shell_*.tar.gz -C / opt
           arch="$(uname -m)"
           if [ -f /usr/local/share/opentelemetry_shell/agent.instrumentation.http/"$arch"/libinjecthttpheader.dylib ]; then
             sudo mv /usr/local/share/opentelemetry_shell/agent.instrumentation.http/"$arch"/libinjecthttpheader.dylib /usr/local/share/opentelemetry_shell/agent.instrumentation.http/

--- a/.github/workflows/test_shell.yml
+++ b/.github/workflows/test_shell.yml
@@ -9,7 +9,7 @@ jobs:
   smoke:
     strategy:
       matrix:
-        runner: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-latest', 'macos-13']
+        runner: ['ubuntu-latest', 'ubuntu-24.04-arm', 'macos-latest']
       fail-fast: false
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -33,12 +33,16 @@ jobs:
       - if: runner.os == 'macOS'
         run: |
           brew install jq wget curl bash coreutils findutils grep gnu-sed gawk
-          sudo tar -xzf opentelemetry-shell_*.tar.gz -C /
+          # /usr is on the SIP-sealed system volume on modern macOS, so the package has to live under
+          # /usr/local instead; --strip-components=2 turns the tarball's usr/bin, usr/share/... into
+          # bin/..., share/... so they land directly at /usr/local/bin, /usr/local/share/opentelemetry_shell
+          sudo mkdir -p /usr/local/bin /usr/local/share
+          sudo tar --strip-components=2 -xzf opentelemetry-shell_*.tar.gz -C /usr/local
           arch="$(uname -m)"
-          if [ -f /usr/share/opentelemetry_shell/agent.instrumentation.http/"$arch"/libinjecthttpheader.dylib ]; then
-            sudo mv /usr/share/opentelemetry_shell/agent.instrumentation.http/"$arch"/libinjecthttpheader.dylib /usr/share/opentelemetry_shell/agent.instrumentation.http/
+          if [ -f /usr/local/share/opentelemetry_shell/agent.instrumentation.http/"$arch"/libinjecthttpheader.dylib ]; then
+            sudo mv /usr/local/share/opentelemetry_shell/agent.instrumentation.http/"$arch"/libinjecthttpheader.dylib /usr/local/share/opentelemetry_shell/agent.instrumentation.http/
           fi
-          sudo find /usr/share/opentelemetry_shell/agent.instrumentation.http -mindepth 1 -type d -exec rm -rf {} + 2>/dev/null || true
+          sudo find /usr/local/share/opentelemetry_shell/agent.instrumentation.http -mindepth 1 -type d -exec rm -rf {} + 2>/dev/null || true
           sudo python3 -m venv /opt/opentelemetry_shell/venv
           sudo /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
       - run: bash -c "cd tests && bash run_tests.sh bash"

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -7,11 +7,12 @@ elif type rpm 1> /dev/null 2> /dev/null; then
   extension=rpm
 elif type apk 1> /dev/null 2> /dev/null; then
   extension=apk
-elif [ "$(uname -s)" = "Darwin" ] && type brew 1> /dev/null 2> /dev/null; then
-  echo "Installing opentelemetry-shell via Homebrew..."
-  brew tap plengauer/opentelemetry-shell https://github.com/plengauer/Thoth || true
-  brew install opentelemetry-shell
-  exit 0
+elif [ "$(uname -s)" = "Darwin" ]; then
+  if type brew 1> /dev/null 2> /dev/null && { echo "Installing opentelemetry-shell via Homebrew..."; brew tap plengauer/opentelemetry-shell https://github.com/plengauer/Thoth; brew install opentelemetry-shell; }; then
+    exit 0
+  fi
+  echo "Homebrew unavailable or the tap install failed, falling back to a direct tarball installation..." >&2
+  extension=tar.gz
 else
   echo "Unsupported operating system (no apt-get, no rpm, no apk, and no brew available)" >&2
   exit 1
@@ -36,6 +37,7 @@ curl -L --no-progress-meter https://api.github.com/repos/plengauer/opentelemetry
     deb) jq 'if . | any(.name | endswith("_all.deb")) then .[] | select(.name | endswith("_'"$(arch | sed s/x86_64/amd64/g | sed s/aarch64/arm64/g | sed 's/le$/el/g')"'.deb")) else .[0] end';;
     rpm) jq 'if . | any(.name | endswith(".noarch.rpm")) then .[] | select(.name | endswith("_'"$(arch)"'.rpm")) else .[0] end';;
     apk) jq '.[0]';;
+    tar.gz) jq '.[0]';;
     *) echo "Here be dragons" >&2;;
   esac | jq .browser_download_url -r | xargs -r wget -O "$package"
 if ! [ -r "$package" ]; then
@@ -44,6 +46,7 @@ if ! [ -r "$package" ]; then
       deb) xargs -I '{}' echo -n opentelemetry-shell_'{}'_"$(arch | sed s/x86_64/amd64/g | sed s/aarch64/arm64/g | sed 's/le$/el/g')".deb;;
       rpm) xargs -I '{}' echo -n opentelemetry-shell-'{}'-1."$(arch)".rpm;;
       apk) xargs -I '{}' echo -n opentelemetry-shell-'{}'-r0.apk;;
+      tar.gz) xargs -I '{}' echo -n opentelemetry-shell_'{}'.tar.gz;;
       *) echo "Here be dragons" >&2;;
     esac | xargs -r -I '{}' wget -O "$package" https://github.com/plengauer/Thoth/releases/latest/download/'{}'
 fi
@@ -53,6 +56,7 @@ if ! [ -r "$package" ]; then
       deb) xargs -I '{}' echo -n opentelemetry-shell_'{}'_all.deb;;
       rpm) xargs -I '{}' echo -n opentelemetry-shell-'{}'-1.noarch.rpm;;
       apk) xargs -I '{}' echo -n opentelemetry-shell-'{}'-r0.apk;;
+      tar.gz) xargs -I '{}' echo -n opentelemetry-shell_'{}'.tar.gz;;
       *) echo "Here be dragons" >&2;;
     esac | xargs -r -I '{}' wget -O "$package" https://github.com/plengauer/Thoth/releases/latest/download/'{}'
 fi
@@ -94,6 +98,17 @@ case "$extension" in
     ;;
   apk)
     $wrapper apk add --allow-untrusted "$package"
+    ;;
+  tar.gz)
+    # /usr is on the SIP-sealed system volume on modern macOS, so the usr subtree has to go
+    # under /usr/local instead (--strip-components=2 turns usr/bin, usr/share/... into
+    # bin/..., share/...). /opt is not sealed, so the opt subtree keeps its normal location
+    # and only needs the leading ./ stripped.
+    $wrapper mkdir -p /usr/local/bin /usr/local/share
+    $wrapper tar --strip-components=2 -xzf "$package" -C /usr/local usr
+    $wrapper tar --strip-components=1 -xzf "$package" -C / opt
+    $wrapper python3 -m venv /opt/opentelemetry_shell/venv
+    $wrapper /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
     ;;
   *)
     echo Here be dragons >&2

--- a/actions/instrument/shared/install.sh
+++ b/actions/instrument/shared/install.sh
@@ -21,9 +21,9 @@ if ! type otel.sh 2> /dev/null; then
       tarball_file=/tmp/opentelemetry-shell.tar.gz
       GITHUB_REPOSITORY="$GITHUB_ACTION_REPOSITORY" gh_release "$action_tag_name" | jq '.assets[] | select(.name | endswith(".tar.gz")) | .url' -r | xargs -0 -I '{}' wget --header "Authorization: Bearer $INPUT_GITHUB_TOKEN" --header 'Accept: application/octet-stream' -O "$tarball_file" '{}'
       sudo mkdir -p /usr/local/share /usr/local/bin /usr/local/opt
-      sudo tar xzf "$tarball_file" -C /usr/local
-      sudo ln -sf /usr/local/usr/bin/otel.sh /usr/local/bin/otel.sh
-      sudo ln -sf /usr/local/usr/bin/otelapi.sh /usr/local/bin/otelapi.sh
+      # /usr is on the SIP-sealed system volume on macOS, so install under /usr/local instead;
+      # --strip-components=2 turns the tarball's usr/bin, usr/share/... into bin/..., share/...
+      sudo tar --strip-components=2 -xzf "$tarball_file" -C /usr/local
       rm "$tarball_file"
     )
   elif [ "$GITHUB_REPOSITORY" = "$GITHUB_ACTION_REPOSITORY" ] && [ -f "$GITHUB_WORKSPACE"/package.deb ]; then
@@ -39,9 +39,8 @@ if ! type otel.sh 2> /dev/null; then
       echo ::warning::'Cannot find release for specified tag, falling back to latest. This may be due to tags that haven'\''t finished building yet (like in a fresh fork), in which case this will resolve automatically.' >&2
       if [ "$(uname -s)" = "Darwin" ]; then
         curl --fail -L -s -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" "${GITHUB_API_URL:-https://api.github.com}"/repos/"$GITHUB_ACTION_REPOSITORY"/releases/latest | jq '.assets[] | select(.name | endswith(".tar.gz")) | .url' -r | xargs -0 -I '{}' wget --header "Authorization: Bearer $INPUT_GITHUB_TOKEN" --header 'Accept: application/octet-stream' -O /tmp/package.tar.gz '{}'
-        sudo tar xzf /tmp/package.tar.gz -C /usr/local
-        sudo ln -sf /usr/local/usr/bin/otel.sh /usr/local/bin/otel.sh
-        sudo ln -sf /usr/local/usr/bin/otelapi.sh /usr/local/bin/otelapi.sh
+        sudo mkdir -p /usr/local/share /usr/local/bin
+        sudo tar --strip-components=2 -xzf /tmp/package.tar.gz -C /usr/local
         rm /tmp/package.tar.gz
       else
         curl --fail -L -s -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" "${GITHUB_API_URL:-https://api.github.com}"/repos/"$GITHUB_ACTION_REPOSITORY"/releases/latest | jq '.assets[] | select(.name | endswith(".deb")) | .url' -r | xargs -0 -I '{}' wget --header "Authorization: Bearer $INPUT_GITHUB_TOKEN" --header 'Accept: application/octet-stream' -O /tmp/package.deb '{}'

--- a/actions/instrument/shared/install.sh
+++ b/actions/instrument/shared/install.sh
@@ -20,10 +20,15 @@ if ! type otel.sh 2> /dev/null; then
       [ "$action_tag_name" = main ] || action_tag_name=v"$(cat ../../../VERSION)"
       tarball_file=/tmp/opentelemetry-shell.tar.gz
       GITHUB_REPOSITORY="$GITHUB_ACTION_REPOSITORY" gh_release "$action_tag_name" | jq '.assets[] | select(.name | endswith(".tar.gz")) | .url' -r | xargs -0 -I '{}' wget --header "Authorization: Bearer $INPUT_GITHUB_TOKEN" --header 'Accept: application/octet-stream' -O "$tarball_file" '{}'
-      sudo mkdir -p /usr/local/share /usr/local/bin /usr/local/opt
-      # /usr is on the SIP-sealed system volume on macOS, so install under /usr/local instead;
-      # --strip-components=2 turns the tarball's usr/bin, usr/share/... into bin/..., share/...
-      sudo tar --strip-components=2 -xzf "$tarball_file" -C /usr/local
+      sudo mkdir -p /usr/local/share /usr/local/bin
+      # /usr is on the SIP-sealed system volume on macOS, so the usr subtree goes under /usr/local
+      # instead (--strip-components=2 turns usr/bin, usr/share/... into bin/..., share/...), while
+      # the opt subtree keeps its normal location because /opt is not sealed and api.sh expects
+      # the SDK venv at /opt/opentelemetry_shell/venv
+      sudo tar --strip-components=2 -xzf "$tarball_file" -C /usr/local usr
+      sudo tar --strip-components=1 -xzf "$tarball_file" -C / opt
+      sudo python3 -m venv /opt/opentelemetry_shell/venv
+      sudo /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
       rm "$tarball_file"
     )
   elif [ "$GITHUB_REPOSITORY" = "$GITHUB_ACTION_REPOSITORY" ] && [ -f "$GITHUB_WORKSPACE"/package.deb ]; then
@@ -40,7 +45,10 @@ if ! type otel.sh 2> /dev/null; then
       if [ "$(uname -s)" = "Darwin" ]; then
         curl --fail -L -s -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" "${GITHUB_API_URL:-https://api.github.com}"/repos/"$GITHUB_ACTION_REPOSITORY"/releases/latest | jq '.assets[] | select(.name | endswith(".tar.gz")) | .url' -r | xargs -0 -I '{}' wget --header "Authorization: Bearer $INPUT_GITHUB_TOKEN" --header 'Accept: application/octet-stream' -O /tmp/package.tar.gz '{}'
         sudo mkdir -p /usr/local/share /usr/local/bin
-        sudo tar --strip-components=2 -xzf /tmp/package.tar.gz -C /usr/local
+        sudo tar --strip-components=2 -xzf /tmp/package.tar.gz -C /usr/local usr
+        sudo tar --strip-components=1 -xzf /tmp/package.tar.gz -C / opt
+        sudo python3 -m venv /opt/opentelemetry_shell/venv
+        sudo /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
         rm /tmp/package.tar.gz
       else
         curl --fail -L -s -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" "${GITHUB_API_URL:-https://api.github.com}"/repos/"$GITHUB_ACTION_REPOSITORY"/releases/latest | jq '.assets[] | select(.name | endswith(".deb")) | .url' -r | xargs -0 -I '{}' wget --header "Authorization: Bearer $INPUT_GITHUB_TOKEN" --header 'Accept: application/octet-stream' -O /tmp/package.deb '{}'

--- a/meta/homebrew/opentelemetry-shell.rb
+++ b/meta/homebrew/opentelemetry-shell.rb
@@ -8,7 +8,7 @@ class OpentelemetryShell < Formula
 
   depends_on "coreutils"
   depends_on "findutils"
-  depends_on "python@3.9" => :recommended
+  depends_on "python@3" => :recommended
   depends_on "grep"
   depends_on "gnu-sed"
   depends_on "gawk"
@@ -22,7 +22,9 @@ class OpentelemetryShell < Formula
   end
 
   def post_install
-    system "#{prefix}/opt/opentelemetry_shell/venv/bin/python3", "-m", "venv", "#{prefix}/opt/opentelemetry_shell/venv"
+    # the venv doesn't exist yet, so it has to be created with the dependency's python3 (on PATH
+    # during the build), not the venv's own not-yet-created python3
+    system "python3", "-m", "venv", "#{prefix}/opt/opentelemetry_shell/venv"
     system "#{prefix}/opt/opentelemetry_shell/venv/bin/pip3", "install", "-r", "#{prefix}/opt/opentelemetry_shell/requirements.txt"
   end
 
@@ -30,6 +32,12 @@ class OpentelemetryShell < Formula
     <<~EOS
       To use OpenTelemetry in your shell scripts, source the file:
         . #{bin}/otel.sh
+
+      Note: this formula's scripts look for their own files under the fixed path
+      /usr/local/share/opentelemetry_shell rather than #{prefix}, so on Apple Silicon
+      (where Homebrew's prefix is #{HOMEBREW_PREFIX}, not /usr/local) that lookup will
+      fail unless /usr/local/share/opentelemetry_shell also exists, e.g. as a symlink to
+      #{prefix}/usr/share/opentelemetry_shell.
 
       For more information, see:
         https://github.com/plengauer/opentelemetry-bash

--- a/src/usr/share/opentelemetry_shell/agent.injection.netcat.sh
+++ b/src/usr/share/opentelemetry_shell/agent.injection.netcat.sh
@@ -3,6 +3,6 @@ if [ "${OTEL_SHELL_AUTO_INJECTED:-FALSE}" = TRUE ]; then
   exec "$@"
 else
   . otelapi.sh
-  \eval "$(\grep -vh '_otel_alias_prepend ' /usr/share/opentelemetry_shell/agent.instrumentation.netcat.sh)"
+  \eval "$(\grep -vh '_otel_alias_prepend ' "$_otel_shell_home"/agent.instrumentation.netcat.sh)"
   _otel_inject_netcat "$@"
 fi

--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.curl.sh
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.curl.sh
@@ -7,11 +7,11 @@ _otel_propagate_curl() {
     *m*) local job_control=1; \set +m;;
     *) local job_control=0;;
   esac
-  local file=/usr/share/opentelemetry_shell/agent.instrumentation.http/libinjecthttpheader.so
+  local file="$_otel_shell_home"/agent.instrumentation.http/libinjecthttpheader.so
   if \[ "$(\uname -s)" = "Darwin" ]; then
-    local file=/usr/share/opentelemetry_shell/agent.instrumentation.http/libinjecthttpheader.dylib
+    local file="$_otel_shell_home"/agent.instrumentation.http/libinjecthttpheader.dylib
   fi
-  if \[ -f "$file" ] && ! \ldd "$file" 2> /dev/null | \grep -q 'not found' && ! ( \[ "$_otel_shell" = 'busybox sh' ] && \help | \tail -n +3 | \grep -q curl ); then
+  if \[ -f "$file" ] && ! ( \[ "$(\uname -s)" = "Darwin" ] && \otool -L "$file" 2> /dev/null | \grep -q 'not found' ) && ! \ldd "$file" 2> /dev/null | \grep -q 'not found' && ! ( \[ "$_otel_shell" = 'busybox sh' ] && \help | \tail -n +3 | \grep -q curl ); then
     export OTEL_SHELL_INJECT_HTTP_SDK_PIPE="$_otel_remote_sdk_pipe"
     export OTEL_SHELL_INJECT_HTTP_HANDLE_FILE="$(\mktemp -u -p "$_otel_shell_pipe_dir" opentelemetry_shell_$$.curl.handle.XXXXXXXXXX)"
     if \[ "$(\uname -s)" = "Darwin" ]; then

--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.wget.sh
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.wget.sh
@@ -7,11 +7,11 @@ _otel_propagate_wget() {
     *m*) local job_control=1; \set +m;;
     *) local job_control=0;;
   esac
-  local file=/usr/share/opentelemetry_shell/agent.instrumentation.http/libinjecthttpheader.so
+  local file="$_otel_shell_home"/agent.instrumentation.http/libinjecthttpheader.so
   if \[ "$(\uname -s)" = "Darwin" ]; then
-    local file=/usr/share/opentelemetry_shell/agent.instrumentation.http/libinjecthttpheader.dylib
+    local file="$_otel_shell_home"/agent.instrumentation.http/libinjecthttpheader.dylib
   fi
-  if \[ -f "$file" ] && ! \ldd "$file" 2> /dev/null | \grep -q 'not found' && ! ( \[ "$_otel_shell" = 'busybox sh' ] && \help | \tail -n +3 | \grep -q wget ); then
+  if \[ -f "$file" ] && ! ( \[ "$(\uname -s)" = "Darwin" ] && \otool -L "$file" 2> /dev/null | \grep -q 'not found' ) && ! \ldd "$file" 2> /dev/null | \grep -q 'not found' && ! ( \[ "$_otel_shell" = 'busybox sh' ] && \help | \tail -n +3 | \grep -q wget ); then
     export OTEL_SHELL_INJECT_HTTP_SDK_PIPE="$_otel_remote_sdk_pipe"
     export OTEL_SHELL_INJECT_HTTP_HANDLE_FILE="$(\mktemp -u)_opentelemetry_shell_$$.wget.handle"
     if \[ "$(\uname -s)" = "Darwin" ]; then

--- a/src/usr/share/opentelemetry_shell/agent.sh
+++ b/src/usr/share/opentelemetry_shell/agent.sh
@@ -18,7 +18,7 @@ esac
 _otel_shell_conservative_exec="${OTEL_SHELL_CONSERVATIVE_EXEC:-FALSE}"
 unset OTEL_SHELL_CONSERVATIVE_EXEC
 
-\. /usr/share/opentelemetry_shell/api.sh
+if \[ "$(\uname -s)" = Darwin ]; then \. /usr/local/share/opentelemetry_shell/api.sh; else \. /usr/share/opentelemetry_shell/api.sh; fi
 _otel_package_version opentelemetry-shell > /dev/null # to build the cache outside a subshell
 
 if \[ "$_otel_shell" = "bash" ] && \[ -n "${BASHPID:-}" ] && \[ "$$" != "$BASHPID" ]; then
@@ -111,8 +111,8 @@ _otel_auto_instrument() {
 
 _otel_list_special_auto_instrument_files() {
   case "$-" in
-    *f*) \ls /usr/share/opentelemetry_shell | \grep -E '^agent.instrumentation.*.sh$' | while \read -r _otel_file_name; do \echo /usr/share/opentelemetry_shell/"$_otel_file_name"; done;;
-    *) \echo /usr/share/opentelemetry_shell/agent.instrumentation.*.sh;;
+    *f*) \ls "$_otel_shell_home" | \grep -E '^agent.instrumentation.*.sh$' | while \read -r _otel_file_name; do \echo "$_otel_shell_home"/"$_otel_file_name"; done;;
+    *) \echo "$_otel_shell_home"/agent.instrumentation.*.sh;;
   esac
 }
 
@@ -170,7 +170,8 @@ _otel_filter_commands_by_hint() {
 
 _otel_resolve_instrumentation_hint() {
   local hint="$1"
-  { \[ -f "$hint" ] && \[ "$(\readlink -f "$hint")" != "$(\readlink -f "/proc/$$/exe")" ] && \[ "$(\readlink -f "$hint")" != /usr/share/opentelemetry_shell/agent.sh ] && \cat "$hint" || \echo "$hint"; } | \tr -s ' $=";(){}/\\!#~^'\' '\n' | _otel_filter_by_validity | \sort -u
+  if \[ -d /proc ] && \[ "$(\readlink -f "$hint")" = "$(\readlink -f "/proc/$$/exe")" ]; then local _otel_hint_is_self=TRUE; else local _otel_hint_is_self=FALSE; fi
+  { \[ -f "$hint" ] && \[ "$_otel_hint_is_self" = FALSE ] && \[ "$(\readlink -f "$hint")" != "$_otel_shell_home"/agent.sh ] && \cat "$hint" || \echo "$hint"; } | \tr -s ' $=";(){}/\\!#~^'\' '\n' | _otel_filter_by_validity | \sort -u
 }
 
 _otel_filter_commands_by_instrumentation() {

--- a/src/usr/share/opentelemetry_shell/agent.sh
+++ b/src/usr/share/opentelemetry_shell/agent.sh
@@ -126,8 +126,16 @@ _otel_list_path_commands() {
   _otel_list_path_executables | _otel_path_2_name
 }
 
+# -executable is a GNU extension; BSD find (macOS) errors out on it, which the redirect below
+# would silently swallow and leave nothing to instrument, so use the portable -perm +111 there
+if \[ "$(\uname -s)" = Darwin ]; then
+  _otel_find_type_executable() { \find "$1" -maxdepth 1 -type "$2" -perm +111 2> /dev/null || \true; }
+else
+  _otel_find_type_executable() { \find "$1" -maxdepth 1 -type "$2" -executable 2> /dev/null || \true; }
+fi
+
 _otel_list_path_executables() {
-  \echo "$PATH" | \tr ':' '\n' | while \read dir; do \find "$dir" -maxdepth 1 -type f -executable 2> /dev/null || \true; \find "$dir" -maxdepth 1 -type l -executable 2> /dev/null || \true; done
+  \echo "$PATH" | \tr ':' '\n' | while \read dir; do _otel_find_type_executable "$dir" f; _otel_find_type_executable "$dir" l; done
 }
 
 _otel_path_2_name() {

--- a/src/usr/share/opentelemetry_shell/api.sh
+++ b/src/usr/share/opentelemetry_shell/api.sh
@@ -19,6 +19,7 @@ case "$-" in
 esac
 
 # basic setup
+if \[ "$(\uname -s)" = Darwin ]; then _otel_shell_home=/usr/local/share/opentelemetry_shell; else _otel_shell_home=/usr/share/opentelemetry_shell; fi
 if \[ -z "${TMPDIR:-}" ]; then TMPDIR=/tmp; fi
 _otel_shell_pipe_dir="${OTEL_SHELL_PIPE_DIR:-$TMPDIR}"
 _otel_remote_sdk_pipe="${OTEL_REMOTE_SDK_PIPE:-$(\mktemp -u -p "$_otel_shell_pipe_dir" opentelemetry_shell.$$.sdk.pipe.XXXXXXXXXX)}"
@@ -33,7 +34,11 @@ if \[ -d /proc ]; then
   if \[ "$_otel_shell" = busybox ]; then _otel_shell="busybox sh"; fi
   if \[ "${OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE:-}" = 0 ] || \[ "${OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE:-}" = "$PPID" ] || \[ "${PPID:-}" = 0 ] || { \[ -r /proc/$PPID/cmdline ] && \[ -r "/proc/${OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE:-}/cmdline" ] && \[ "$(\tr '\000-\037' ' ' < /proc/$PPID/cmdline)" = "$(\tr '\000-\037' ' ' < /proc/${OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE:-}/cmdline)" ]; }; then _otel_commandline_override="$OTEL_SHELL_COMMANDLINE_OVERRIDE"; fi
 else
-  _otel_shell="${SHELL##*/}"
+  # no /proc (e.g. macOS): ask ps for the actual running interpreter of this process rather than
+  # trusting $SHELL, which is only the user's login shell and may not match how this file was invoked
+  _otel_shell="$(\ps -p $$ -o comm= 2> /dev/null)"
+  _otel_shell="${_otel_shell##*/}"
+  if \[ -z "$_otel_shell" ]; then _otel_shell="${SHELL##*/}"; fi
   if \[ -z "$_otel_shell" ]; then _otel_shell=sh; fi
   if \[ "$_otel_shell" = busybox ]; then _otel_shell="busybox sh"; fi
   if \[ "${OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE:-}" = 0 ] || \[ "${OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE:-}" = "$PPID" ]; then _otel_commandline_override="$OTEL_SHELL_COMMANDLINE_OVERRIDE"; fi
@@ -62,7 +67,7 @@ else
     else
       # several weird things going on in the next line, (1) using '((' fucks up the syntax highlighting in github while '( (' does not, and (2) &> causes weird buffering / late flushing behavior
       if \env --help 2>&1 | \grep -q 'ignore-signal'; then local extra_env_flags='--ignore-signal=INT --ignore-signal=HUP'; fi
-      ( \exec \env ${extra_env_flags:-} /opt/opentelemetry_shell/venv/bin/python /usr/share/opentelemetry_shell/sdk.py shell "$(_otel_package_version opentelemetry-shell)" < "$_otel_remote_sdk_pipe" 1> "$_otel_remote_sdk_stdout_redirect" 2> "$_otel_remote_sdk_stderr_redirect" &)
+      ( \exec \env ${extra_env_flags:-} /opt/opentelemetry_shell/venv/bin/python "$_otel_shell_home"/sdk.py shell "$(_otel_package_version opentelemetry-shell)" < "$_otel_remote_sdk_pipe" 1> "$_otel_remote_sdk_stdout_redirect" 2> "$_otel_remote_sdk_stderr_redirect" &)
     fi
     \eval "\\exec ${_otel_remote_sdk_fd}> \"$_otel_remote_sdk_pipe\""
     _otel_resource_attributes
@@ -463,9 +468,9 @@ _otel_call() {
   \alias "$command" 1> /dev/null 2> /dev/null && \eval "$(_otel_escape_args "${command#\\}" "$@")" || "${command#\\}" "$@"
 }
 
-\. /usr/share/opentelemetry_shell/api.observe.logs.sh
-\. /usr/share/opentelemetry_shell/api.observe.pipes.sh
-\. /usr/share/opentelemetry_shell/api.observe.subprocesses.sh
+\. "$_otel_shell_home"/api.observe.logs.sh
+\. "$_otel_shell_home"/api.observe.pipes.sh
+\. "$_otel_shell_home"/api.observe.subprocesses.sh
 
 if \[ "$_otel_shell" = bash ]; then
   _otel_command_type() {

--- a/tests/auto/DISABLED_test_auto_injection_with_path.bash
+++ b/tests/auto/DISABLED_test_auto_injection_with_path.bash
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 /bin/bash auto/fail_no_auto.shell
 assert_equals 0 $?

--- a/tests/auto/DISABLED_test_auto_injection_with_script.bash
+++ b/tests/auto/DISABLED_test_auto_injection_with_script.bash
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 auto/fail_no_auto.shell
 assert_equals 0 $?

--- a/tests/auto/curl.sh
+++ b/tests/auto/curl.sh
@@ -1,2 +1,2 @@
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 curl "$@"

--- a/tests/auto/curl_subshell.sh
+++ b/tests/auto/curl_subshell.sh
@@ -1,2 +1,2 @@
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 (curl http://www.google.com/)

--- a/tests/auto/exec.sh
+++ b/tests/auto/exec.sh
@@ -1,5 +1,5 @@
 set -e
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 if [ "$OPEN_FD" = TRUE ]; then exec 3>&2; fi
 if [ "$SOURCE" = TRUE ]; then
   file="$(\mktemp)"

--- a/tests/auto/test_auto_[.sh
+++ b/tests/auto/test_auto_[.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 if [ -n "hello world if" ]; then
   echo hello world

--- a/tests/auto/test_auto_alias.sh
+++ b/tests/auto/test_auto_alias.sh
@@ -1,4 +1,4 @@
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 count_0=$(alias | wc -l)
 alias la='ls -a'

--- a/tests/auto/test_auto_http_injection_cleanup.sh
+++ b/tests/auto/test_auto_http_injection_cleanup.sh
@@ -11,7 +11,7 @@ server_pid="$!"
 trap 'kill "$server_pid" 1> /dev/null 2> /dev/null || true' EXIT
 \sleep 1
 
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 old_ld_preload="${LD_PRELOAD:-}"
 url=http://127.0.0.1:"$port"/file
 

--- a/tests/auto/test_auto_init_in_if.sh
+++ b/tests/auto/test_auto_init_in_if.sh
@@ -1,6 +1,6 @@
 . ./assert.sh
 if [ ! -f "FILE_THAT_DOES_NOT_EXIST" ]; then
-  . /usr/bin/opentelemetry_shell.sh
+  . ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 fi
 
 echo hello world

--- a/tests/auto/test_auto_injection.sh
+++ b/tests/auto/test_auto_injection.sh
@@ -1,7 +1,7 @@
 if [ -d /proc ] && [ "$(readlink -f /proc/$$/exe | sed 's#.*/##')" = busybox ]; then exit 0; fi
 
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 eval "$TEST_SHELL auto/fail_no_auto.sh"
 assert_equals 0 $?

--- a/tests/auto/test_auto_injection_c.sh
+++ b/tests/auto/test_auto_injection_c.sh
@@ -1,7 +1,7 @@
 if [ -d /proc ] && [ "$(readlink -f /proc/$$/exe | sed 's#.*/##')" = busybox ]; then exit 0; fi
 
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 eval "$TEST_SHELL -c -- 'echo hello world'"
 assert_equals 0 $?

--- a/tests/auto/test_auto_injection_docker.sh
+++ b/tests/auto/test_auto_injection_docker.sh
@@ -1,7 +1,7 @@
 if ! type docker; then exit 0; fi
 
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 assert_equals "hello world 0" "$(sudo docker run debian:latest echo hello world 0)"
 span="$(resolve_span '.name == "echo hello world 0"')"

--- a/tests/auto/test_auto_injection_find.sh
+++ b/tests/auto/test_auto_injection_find.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 n=5
 

--- a/tests/auto/test_auto_injection_flock.sh
+++ b/tests/auto/test_auto_injection_flock.sh
@@ -3,7 +3,7 @@ if [ -x .lock ]; then exit 0; fi
 # chmod +x .lock
 
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 output="$(flock .lock echo hello world)"
 assert_equals "hello world" "$output"

--- a/tests/auto/test_auto_injection_parallel.sh
+++ b/tests/auto/test_auto_injection_parallel.sh
@@ -1,6 +1,6 @@
 if ! type parallel; then exit 0; fi
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 if type dpkg && dpkg -s moreutils; then
   parallel.moreutils echo -- a1 a2 a3

--- a/tests/auto/test_auto_injection_shebang.sh
+++ b/tests/auto/test_auto_injection_shebang.sh
@@ -8,7 +8,7 @@ else
   cat auto/fail_no_auto.sh | sudo tee -a /usr/bin/fail_no_auto.sh
   sudo chmod +x /usr/bin/fail_no_auto.sh
 fi
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 fail_no_auto.sh
 assert_equals 0 $?
 span="$(resolve_span '.resource.attributes."process.command_line" | contains("/fail_no_auto.sh")')"

--- a/tests/auto/test_auto_injection_stdin.sh
+++ b/tests/auto/test_auto_injection_stdin.sh
@@ -1,7 +1,7 @@
 if [ -d /proc ] && [ "$(readlink -f /proc/$$/exe | sed 's#.*/##')" = busybox ]; then exit 0; fi
 
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 cat auto/fail_no_auto.sh | eval "$TEST_SHELL"
 assert_equals 0 $?

--- a/tests/auto/test_auto_injection_sudo.sh
+++ b/tests/auto/test_auto_injection_sudo.sh
@@ -1,6 +1,6 @@
 if ! type sudo; then exit 0; fi
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 sudo echo hello world
 assert_equals 0 $?

--- a/tests/auto/test_auto_injection_sudo_whitespaces.sh
+++ b/tests/auto/test_auto_injection_sudo_whitespaces.sh
@@ -1,6 +1,6 @@
 if ! type sudo; then exit 0; fi
 . ./assert.sh
 export OTEL_SERVICE_NAME="Test Service with Whitespaces"
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 sudo echo hello world
 assert_equals 0 $?

--- a/tests/auto/test_auto_injection_time.sh
+++ b/tests/auto/test_auto_injection_time.sh
@@ -1,7 +1,7 @@
 if [ "$SHELL" = sh ] && type rpm; then exit 0; fi
 
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 time echo hello world
 assert_equals 0 $?

--- a/tests/auto/test_auto_injection_timeout.sh
+++ b/tests/auto/test_auto_injection_timeout.sh
@@ -1,6 +1,6 @@
 if type rpm; then exit 0; fi
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 timeout 60s echo hello world 1
 assert_equals 0 $?

--- a/tests/auto/test_auto_injection_whitespaces.sh
+++ b/tests/auto/test_auto_injection_whitespaces.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 assert_equals 0 $(eval "$TEST_SHELL auto/count_fail_no_auto.sh")
 assert_equals 1 $(eval "$TEST_SHELL auto/count_fail_no_auto.sh foo")

--- a/tests/auto/test_auto_injection_xargs.sh
+++ b/tests/auto/test_auto_injection_xargs.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 file=$(mktemp)
 echo "hello world 0" >> $file

--- a/tests/auto/test_auto_instrument.sh
+++ b/tests/auto/test_auto_instrument.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 echo hello world
 

--- a/tests/auto/test_auto_lifecycle.sh
+++ b/tests/auto/test_auto_lifecycle.sh
@@ -1,4 +1,4 @@
 set -e
 
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 

--- a/tests/auto/test_auto_minimal_instrumentation.sh
+++ b/tests/auto/test_auto_minimal_instrumentation.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 alias
 
 if [ -n "$(alias | grep ech | grep cho)" ]; then printf '%s\n' "e-cho has been instrumented"; exit 1; fi
@@ -18,7 +18,7 @@ if [ -n "$(alias alias | grep otel_observe)" ] || [ -n "$(alias unalias | grep o
 fi
 
 file=$(mktemp)
-$TEST_SHELL -c '. /usr/bin/opentelemetry_shell.sh
+$TEST_SHELL -c '. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 alias' | sed 's/^alias //g' | cut -d= -f1 > $file
 assert_equals "" "$(cat $file | grep '^OTEL_')"
 assert_equals "" "$(cat $file | grep '^_otel_')"

--- a/tests/auto/test_auto_traceparent.sh
+++ b/tests/auto/test_auto_traceparent.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 traceparent=$TRACEPARENT
 assert_not_equals "" "$TRACEPARENT"

--- a/tests/auto/wget.sh
+++ b/tests/auto/wget.sh
@@ -1,2 +1,2 @@
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 wget -O - "$@"

--- a/tests/auto/wget2.sh
+++ b/tests/auto/wget2.sh
@@ -1,2 +1,2 @@
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 wget2 -O - "$@"

--- a/tests/integration/test_integration__bash_ai__shebang_vs_alias_injection.sh
+++ b/tests/integration/test_integration__bash_ai__shebang_vs_alias_injection.sh
@@ -8,7 +8,7 @@ sudo sh -c 'echo "echo hello world" >> /usr/bin/bash-ai' # lets abstract away th
 sudo chmod +x /usr/bin/bash-ai
 alias ai=bash-ai
 # lets simulate the caller
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 if [ "$TEST_SHELL" = 'busybox sh' ] && ! [ -x /bin/busybox ]; then sudo ln --symbolic $(which busybox) /bin/busybox; fi
 alias
 ai some arguments

--- a/tests/integration/test_integration__philbot_stop__multi_tier_injection.sh
+++ b/tests/integration/test_integration__philbot_stop__multi_tier_injection.sh
@@ -4,7 +4,7 @@ if ! dpkg -s moreutils; then exit 0; fi
 # from a real world example
 
 # lets simulate the caller
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 seq -s " philbot-discordgateway2http_" 0 3 | xargs -I '{}' echo philbot-discordgateway2http_'{}' | xargs parallel.moreutils -j 3 sh -c 'echo docker rm --force $1' echo --
 # in reality the parallel command stops a docker container, but echo should be enough for this
 

--- a/tests/integration/test_integration__renovate.sh
+++ b/tests/integration/test_integration__renovate.sh
@@ -1,7 +1,7 @@
 # renovate is really a docker running an npm package, that is pre-isntrumented with otel running in a docker container that during startup runs through an exec and a shebang first!
 if ! type docker; then exit 0; fi
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 
 log_file="$(\mktemp)"
 docker run --rm --env RENOVATE_DRY_RUN=full --env RENOVATE_TOKEN=abc --env RENOVATE_REPOSITORIES="plengauer/opentelemetry-bash" ghcr.io/renovatebot/renovate:latest > "$log_file"

--- a/tests/integration/test_integration__which__IFS.sh
+++ b/tests/integration/test_integration__which__IFS.sh
@@ -1,7 +1,7 @@
 if ! type which; then exit 0; fi
 # which is really a shell script with a shebang and it does some IFS magic
 . ./assert.sh
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 assert_equals "$(\which flock)" "$(which flock)"
 span="$(resolve_span '.name | endswith("which flock")')"
 assert_equals "SpanKind.INTERNAL" $(\echo "$span" | jq -r '.kind')

--- a/tests/integration/test_integration_debconf_arguments.bash
+++ b/tests/integration/test_integration_debconf_arguments.bash
@@ -3,7 +3,7 @@
 if ! [ -f /usr/share/debconf/confmodule ]; then exit 0; fi
 
 simple_command='. /usr/share/debconf/confmodule; echo $2 >&2'
-command=". /usr/bin/opentelemetry_shell.sh; $simple_command"
+command=". ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}; $simple_command"
 
 script="$(mktemp)"
 chmod +x "$script"
@@ -14,6 +14,6 @@ assert_equals bar "$(bash "$script" foo bar baz 2>&1 | grep -v 'debconf')"
 script="$(mktemp)"
 chmod +x "$script"
 echo "$simple_command" > "$script"
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 assert_equals bar "$(bash "$script" foo bar baz 2>&1 | grep -v 'debconf')"
 # assert_equals bar "$(bash -c "$simple_command" bash foo bar baz)" # this does not work with debconf, with and without instrumentation

--- a/tests/integration/test_integration_debconf_first.sh
+++ b/tests/integration/test_integration_debconf_first.sh
@@ -3,6 +3,6 @@ if ! [ -f /usr/share/debconf/confmodule ]; then exit 0; fi
 set +u
 export DEBIAN_FRONTEND=noninteractive
 . /usr/share/debconf/confmodule
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 db_get $(debconf-show $(debconf-show --listowners | head -n1) | sed 's/^\* //' | sed 's/  //' | cut -d: -f1 | head -n1)
 assert_equals 0 "$?"

--- a/tests/integration/test_integration_debconf_second.sh
+++ b/tests/integration/test_integration_debconf_second.sh
@@ -1,6 +1,6 @@
 . ./assert.sh
 if ! [ -f /usr/share/debconf/confmodule ]; then exit 0; fi
-. /usr/bin/opentelemetry_shell.sh
+. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 set +u
 export DEBIAN_FRONTEND=noninteractive
 . /usr/share/debconf/confmodule

--- a/tests/performance/test_performance_full.sh
+++ b/tests/performance/test_performance_full.sh
@@ -1,4 +1,4 @@
 set -e
 
-timeout 90s sh -c '. /usr/bin/opentelemetry_shell.sh
+timeout 90s sh -c '. ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}
 exit 0'

--- a/tests/performance/test_performance_script.sh
+++ b/tests/performance/test_performance_script.sh
@@ -4,7 +4,7 @@ set -e
 
 script="$(mktemp).$SHELL"
 echo "#!/bin/$SHELL" >> "$script"
-echo ". /usr/bin/opentelemetry_shell.sh" >> "$script"
+echo ". ${OTEL_TEST_ENTRYPOINT:-/usr/bin/opentelemetry_shell.sh}" >> "$script"
 # echo "\alias" >> "$script"
 echo "exit 0" >> "$script"
 echo "curl http://www.google.at" >> "$script"

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -10,11 +10,22 @@ if [ "$SHELL" = dash ] && ! ( [ "$ID" = debian ] || [ "$ID_LIKE" = debian ] ); t
   exit 0
 fi
 
-if ! type timeout; then
+if ! type perl 1> /dev/null 2> /dev/null; then
+  function perl() {
+    cat
+  }
+fi
+
+if ! type timeout 1> /dev/null 2> /dev/null; then
   function timeout() {
     shift
     "$@"
   }
+fi
+
+if [ "$(uname -s)" = "Darwin" ]; then
+  export OTEL_TEST_ENTRYPOINT=/usr/local/bin/opentelemetry_shell.sh
+  export OTEL_TEST_API_ENTRYPOINT=/usr/local/bin/opentelemetry_shell_api.sh
 fi
 
 if [ "$SHELL" = busybox ]; then

--- a/tests/sdk/DISABLED_test_sdk_observe_pipes_detached_stdin.sh
+++ b/tests/sdk/DISABLED_test_sdk_observe_pipes_detached_stdin.sh
@@ -1,7 +1,7 @@
 # DISABLED because such a situation is super hard to reproduce manually
 # in this case the stdin tee will try to read (maybe), process will either hang or terminate, and that will in turn then kill the tee
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 exec 0<&-
 export OTEL_SHELL_EXPERIMENTAL_OBSERVE_PIPES=TRUE

--- a/tests/sdk/test_log_sideeffects.sh
+++ b/tests/sdk/test_log_sideeffects.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 

--- a/tests/sdk/test_sdk_init_shutdown.sh
+++ b/tests/sdk/test_sdk_init_shutdown.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 assert_equals 0 $?

--- a/tests/sdk/test_sdk_metric.sh
+++ b/tests/sdk/test_sdk_metric.sh
@@ -1,5 +1,5 @@
 set -e
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 

--- a/tests/sdk/test_sdk_observe.sh
+++ b/tests/sdk/test_sdk_observe.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 if [ "$SHELL" = "bash" ]; then
   shopt -s expand_aliases

--- a/tests/sdk/test_sdk_observe_exit.sh
+++ b/tests/sdk/test_sdk_observe_exit.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 func_fail() {

--- a/tests/sdk/test_sdk_observe_failed.sh
+++ b/tests/sdk/test_sdk_observe_failed.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 otel_observe cat FILE_THAT_DOES_NOT_EXIST

--- a/tests/sdk/test_sdk_observe_log.sh
+++ b/tests/sdk/test_sdk_observe_log.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 otel_observe $TEST_SHELL sdk/log.sh

--- a/tests/sdk/test_sdk_observe_pipes.sh
+++ b/tests/sdk/test_sdk_observe_pipes.sh
@@ -1,7 +1,7 @@
 . ./assert.sh
 export OTEL_SHELL_CONFIG_OBSERVE_PIPES=TRUE
 export OTEL_SHELL_CONFIG_OBSERVE_PIPES_STDIN=TRUE
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 assert_equals "hello

--- a/tests/sdk/test_sdk_observe_pipes_detached_stdout.bash
+++ b/tests/sdk/test_sdk_observe_pipes_detached_stdout.bash
@@ -2,7 +2,7 @@
 . ./assert.sh
 export OTEL_SHELL_CONFIG_OBSERVE_PIPES=TRUE
 export OTEL_SHELL_CONFIG_OBSERVE_PIPES_STDIN=TRUE
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 exec 1>&-
 otel_init

--- a/tests/sdk/test_sdk_observe_pipes_empty.sh
+++ b/tests/sdk/test_sdk_observe_pipes_empty.sh
@@ -1,7 +1,7 @@
 . ./assert.sh
 export OTEL_SHELL_CONFIG_OBSERVE_PIPES=TRUE
 export OTEL_SHELL_CONFIG_OBSERVE_PIPES_STDIN=TRUE
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 assert_equals "" "$(echo -n '' | otel_observe cat)"

--- a/tests/sdk/test_sdk_observe_stderr.sh
+++ b/tests/sdk/test_sdk_observe_stderr.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 func_print() {

--- a/tests/sdk/test_sdk_observe_stdout.sh
+++ b/tests/sdk/test_sdk_observe_stdout.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 result=$(otel_observe echo "hello world")

--- a/tests/sdk/test_sdk_observe_whitespaces.sh
+++ b/tests/sdk/test_sdk_observe_whitespaces.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 func_count() {

--- a/tests/sdk/test_sdk_resource_attributes.sh
+++ b/tests/sdk/test_sdk_resource_attributes.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 export OTEL_SERVICE_NAME=TEST
 

--- a/tests/sdk/test_sdk_span.sh
+++ b/tests/sdk/test_sdk_span.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 span_id=$(otel_span_start CONSUMER myspan)

--- a/tests/sdk/test_sdk_span_attribute.sh
+++ b/tests/sdk/test_sdk_span_attribute.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 span_id=$(otel_span_start SERVER myspan)

--- a/tests/sdk/test_sdk_span_error.sh
+++ b/tests/sdk/test_sdk_span_error.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 span_id=$(otel_span_start PRODUCER myspan)

--- a/tests/sdk/test_sdk_span_event.sh
+++ b/tests/sdk/test_sdk_span_event.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 span_id=$(otel_span_start PRODUCER myspan)

--- a/tests/sdk/test_sdk_traceparent.sh
+++ b/tests/sdk/test_sdk_traceparent.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 otel_init
 assert_equals "" "${TRACEPARENT:-}"

--- a/tests/unit/test_unit_busybox_parses_otelapi.sh
+++ b/tests/unit/test_unit_busybox_parses_otelapi.sh
@@ -1,4 +1,4 @@
 . ./assert.sh
 if ! \type busybox 1> /dev/null 2> /dev/null; then exit 0; fi
-busybox sh -n /usr/bin/opentelemetry_shell_api.sh
+busybox sh -n ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 assert_equals 0 "$?"

--- a/tests/unit/test_unit_escape_arg.sh
+++ b/tests/unit/test_unit_escape_arg.sh
@@ -1,5 +1,5 @@
 . ./assert.sh
-. /usr/bin/opentelemetry_shell_api.sh
+. ${OTEL_TEST_API_ENTRYPOINT:-/usr/bin/opentelemetry_shell_api.sh}
 
 assert_equals "hello" "$(_otel_escape_arg "hello")"
 assert_equals "'hello world'" "$(_otel_escape_arg "hello world")"


### PR DESCRIPTION
## Summary
\`INSTALL.sh\`'s Darwin branch only offered \`brew tap ... && brew install\` — and that tap doesn't exist yet, so a real user running \`INSTALL.sh\` on a Mac today gets a hard failure. The tarball + \`--strip-components=2\` extraction into \`/usr/local\` is the mechanism already fixed in #3942 and exercised by the CI smoke test.

Adds a tarball-download-and-extract fallback to \`INSTALL.sh\`'s Darwin branch, used when \`brew\` isn't present or the tap install fails — mirroring how the Linux branches already fall back between API-based and direct-download release fetching. This makes the tested path the one real users get by default, with Homebrew as a secondary option.

Depends on #3942 (base branch).

## Test plan
- [ ] \`sh -n\`/\`dash -n\` on \`INSTALL.sh\` (done locally)
- [ ] Manual: run against a real GitHub release once one exists with a \`.tar.gz\` asset

🤖 Generated with [Claude Code](https://claude.com/claude-code)