### PR TITLE
macOS: wire tarball installs to run the real postinst + bundle node_modules

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -757,6 +757,11 @@ jobs:
           find . -name '*.so' -delete
           find . -mindepth 1 -type d -empty -delete
       - run: |
+          # ship the same postinst that deb/rpm/apk run, as a top-level file in the tarball, so
+          # tarball-based installs (macOS has no package manager postinst hook of its own) can
+          # invoke it themselves instead of duplicating its venv/deep-injection setup logic
+          cp meta/debian/postinst src/postinst
+      - run: |
           version="$(cat VERSION)"
           tar -czf opentelemetry-shell_"$version".tar.gz -C src .
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -726,7 +726,7 @@ jobs:
           if-no-files-found: error
 
   build-brew:
-    needs: [verify-scripts, merge-http]
+    needs: [verify-scripts, merge-http, merge-node-modules]
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -752,6 +752,13 @@ jobs:
         with:
           name: http_${{ inputs.ref }}
           path: src/usr/share/opentelemetry_shell/agent.instrumentation.http
+      # the node deps are pure JS (verified: no .node addons, no binding.gyp anywhere in the
+      # installed tree), so the same node_modules.tar.xz built for deb/rpm/apk works unmodified
+      # here too; postinst (now bundled into the tarball) is what actually extracts it on install
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: node_modules_${{ inputs.ref }}
+          path: src/usr/share/opentelemetry_shell/agent.instrumentation.node
       - run: |
           cd src/usr/share/opentelemetry_shell/agent.instrumentation.http
           find . -name '*.so' -delete

--- a/.github/workflows/test_shell.yml
+++ b/.github/workflows/test_shell.yml
@@ -46,8 +46,12 @@ jobs:
             sudo mv /usr/local/share/opentelemetry_shell/agent.instrumentation.http/"$arch"/libinjecthttpheader.dylib /usr/local/share/opentelemetry_shell/agent.instrumentation.http/
           fi
           sudo find /usr/local/share/opentelemetry_shell/agent.instrumentation.http -mindepth 1 -type d -exec rm -rf {} + 2>/dev/null || true
-          sudo python3 -m venv /opt/opentelemetry_shell/venv
-          sudo /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
+          # the tarball ships the same postinst that deb/rpm/apk run on install; invoke it instead
+          # of duplicating its venv setup (and deep node/python instrumentation) here
+          postinst_script="$(mktemp)"
+          tar -xzf opentelemetry-shell_*.tar.gz -O postinst > "$postinst_script"
+          sudo sh "$postinst_script" configure
+          rm -f "$postinst_script"
       - run: bash -c "cd tests && bash run_tests.sh bash"
       - if: runner.os == 'Linux'
         run: sudo apt-get -y remove opentelemetry-shell

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -107,8 +107,12 @@ case "$extension" in
     $wrapper mkdir -p /usr/local/bin /usr/local/share
     $wrapper tar --strip-components=2 -xzf "$package" -C /usr/local usr
     $wrapper tar --strip-components=1 -xzf "$package" -C / opt
-    $wrapper python3 -m venv /opt/opentelemetry_shell/venv
-    $wrapper /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
+    # the tarball ships the same postinst that deb/rpm/apk run below; invoke it instead of
+    # duplicating its venv setup (and deep node/python instrumentation) here
+    postinst_script="$(mktemp)"
+    tar -xzf "$package" -O postinst > "$postinst_script"
+    $wrapper sh "$postinst_script" configure
+    rm -f "$postinst_script"
     ;;
   *)
     echo Here be dragons >&2

--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -7,11 +7,12 @@ elif type rpm 1> /dev/null 2> /dev/null; then
   extension=rpm
 elif type apk 1> /dev/null 2> /dev/null; then
   extension=apk
-elif [ "$(uname -s)" = "Darwin" ] && type brew 1> /dev/null 2> /dev/null; then
-  echo "Installing opentelemetry-shell via Homebrew..."
-  brew tap plengauer/opentelemetry-shell https://github.com/plengauer/Thoth || true
-  brew install opentelemetry-shell
-  exit 0
+elif [ "$(uname -s)" = "Darwin" ]; then
+  if type brew 1> /dev/null 2> /dev/null && { echo "Installing opentelemetry-shell via Homebrew..."; brew tap plengauer/opentelemetry-shell https://github.com/plengauer/Thoth; brew install opentelemetry-shell; }; then
+    exit 0
+  fi
+  echo "Homebrew unavailable or the tap install failed, falling back to a direct tarball installation..." >&2
+  extension=tar.gz
 else
   echo "Unsupported operating system (no apt-get, no rpm, no apk, and no brew available)" >&2
   exit 1
@@ -36,6 +37,7 @@ curl -L --no-progress-meter https://api.github.com/repos/plengauer/opentelemetry
     deb) jq 'if . | any(.name | endswith("_all.deb")) then .[] | select(.name | endswith("_'"$(arch | sed s/x86_64/amd64/g | sed s/aarch64/arm64/g | sed 's/le$/el/g')"'.deb")) else .[0] end';;
     rpm) jq 'if . | any(.name | endswith(".noarch.rpm")) then .[] | select(.name | endswith("_'"$(arch)"'.rpm")) else .[0] end';;
     apk) jq '.[0]';;
+    tar.gz) jq '.[0]';;
     *) echo "Here be dragons" >&2;;
   esac | jq .browser_download_url -r | xargs -r wget -O "$package"
 if ! [ -r "$package" ]; then
@@ -44,6 +46,7 @@ if ! [ -r "$package" ]; then
       deb) xargs -I '{}' echo -n opentelemetry-shell_'{}'_"$(arch | sed s/x86_64/amd64/g | sed s/aarch64/arm64/g | sed 's/le$/el/g')".deb;;
       rpm) xargs -I '{}' echo -n opentelemetry-shell-'{}'-1."$(arch)".rpm;;
       apk) xargs -I '{}' echo -n opentelemetry-shell-'{}'-r0.apk;;
+      tar.gz) xargs -I '{}' echo -n opentelemetry-shell_'{}'.tar.gz;;
       *) echo "Here be dragons" >&2;;
     esac | xargs -r -I '{}' wget -O "$package" https://github.com/plengauer/Thoth/releases/latest/download/'{}'
 fi
@@ -53,6 +56,7 @@ if ! [ -r "$package" ]; then
       deb) xargs -I '{}' echo -n opentelemetry-shell_'{}'_all.deb;;
       rpm) xargs -I '{}' echo -n opentelemetry-shell-'{}'-1.noarch.rpm;;
       apk) xargs -I '{}' echo -n opentelemetry-shell-'{}'-r0.apk;;
+      tar.gz) xargs -I '{}' echo -n opentelemetry-shell_'{}'.tar.gz;;
       *) echo "Here be dragons" >&2;;
     esac | xargs -r -I '{}' wget -O "$package" https://github.com/plengauer/Thoth/releases/latest/download/'{}'
 fi
@@ -94,6 +98,17 @@ case "$extension" in
     ;;
   apk)
     $wrapper apk add --allow-untrusted "$package"
+    ;;
+  tar.gz)
+    # /usr is on the SIP-sealed system volume on modern macOS, so the usr subtree has to go
+    # under /usr/local instead (--strip-components=2 turns usr/bin, usr/share/... into
+    # bin/..., share/...). /opt is not sealed, so the opt subtree keeps its normal location
+    # and only needs the leading ./ stripped.
+    $wrapper mkdir -p /usr/local/bin /usr/local/share
+    $wrapper tar --strip-components=2 -xzf "$package" -C /usr/local usr
+    $wrapper tar --strip-components=1 -xzf "$package" -C / opt
+    $wrapper python3 -m venv /opt/opentelemetry_shell/venv
+    $wrapper /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
     ;;
   *)
     echo Here be dragons >&2

--- a/actions/instrument/shared/install.sh
+++ b/actions/instrument/shared/install.sh
@@ -27,9 +27,12 @@ if ! type otel.sh 2> /dev/null; then
       # the SDK venv at /opt/opentelemetry_shell/venv
       sudo tar --strip-components=2 -xzf "$tarball_file" -C /usr/local usr
       sudo tar --strip-components=1 -xzf "$tarball_file" -C / opt
-      sudo python3 -m venv /opt/opentelemetry_shell/venv
-      sudo /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
-      rm "$tarball_file"
+      # the tarball ships the same postinst that deb/rpm/apk run on install; invoke it instead of
+      # duplicating its venv setup (and deep node/python instrumentation) here
+      postinst_script="$(mktemp)"
+      tar -xzf "$tarball_file" -O postinst > "$postinst_script"
+      sudo sh "$postinst_script" configure
+      rm -f "$postinst_script" "$tarball_file"
     )
   elif [ "$GITHUB_REPOSITORY" = "$GITHUB_ACTION_REPOSITORY" ] && [ -f "$GITHUB_WORKSPACE"/package.deb ]; then
     echo "::debug::Installing local debian ..."
@@ -47,9 +50,10 @@ if ! type otel.sh 2> /dev/null; then
         sudo mkdir -p /usr/local/share /usr/local/bin
         sudo tar --strip-components=2 -xzf /tmp/package.tar.gz -C /usr/local usr
         sudo tar --strip-components=1 -xzf /tmp/package.tar.gz -C / opt
-        sudo python3 -m venv /opt/opentelemetry_shell/venv
-        sudo /opt/opentelemetry_shell/venv/bin/pip3 install -r /opt/opentelemetry_shell/requirements.txt
-        rm /tmp/package.tar.gz
+        postinst_script="$(mktemp)"
+        tar -xzf /tmp/package.tar.gz -O postinst > "$postinst_script"
+        sudo sh "$postinst_script" configure
+        rm -f "$postinst_script" /tmp/package.tar.gz
       else
         curl --fail -L -s -H "Authorization: Bearer $INPUT_GITHUB_TOKEN" "${GITHUB_API_URL:-https://api.github.com}"/repos/"$GITHUB_ACTION_REPOSITORY"/releases/latest | jq '.assets[] | select(.name | endswith(".deb")) | .url' -r | xargs -0 -I '{}' wget --header "Authorization: Bearer $INPUT_GITHUB_TOKEN" --header 'Accept: application/octet-stream' -O /tmp/package.deb '{}'
         sudo -E -H apt-get install -y /tmp/package.deb


### PR DESCRIPTION
## Summary
Two commits:

1. **Wire tarball-based macOS installs to run the real postinst.** \`INSTALL.sh\`, \`actions/instrument/shared/install.sh\`, and \`test_shell.yml\` each hand-rolled a subset of setup (just the SDK venv) inline after extracting the tarball — a duplicate, out-of-sync copy of what \`meta/debian/postinst\` already does, and one that skipped deep node/python instrumentation setup entirely. \`build-brew\` now copies \`meta/debian/postinst\` into the tarball as a top-level file; all three install sites extract just that file and run it with the same \`configure\` argument dpkg already passes.
2. **Bundle node_modules into the macOS tarball.** \`build-brew\` now depends on \`merge-node-modules\` and downloads its artifact. The node tree was confirmed pure JS (no \`.node\` addons, no \`binding.gyp\`) via a real \`npm install\` of all 446 packages, so the Linux-built artifact is portable as-is — completing the node path started in #3944.

Depends on #3948 (postinst prefix-awareness, base branch) and #3946 (INSTALL.sh tarball fallback — this PR edits the same lines, so its one commit will also appear in this diff until #3946 merges).

## Test plan
- [ ] Verified with a throwaway fixture tarball (build-brew's exact \`tar -C src .\` layout) that extracting the top-level \`postinst\` file via \`tar -xzf pkg -O postinst\` and running it with \`sh script configure\` works with macOS's system bsdtar
- [ ] Security review: no attacker-writable window in the \`mktemp\`-then-\`sudo sh\` pattern (mktemp is atomic/owner-restricted before any privileged step touches it)
- [ ] CI: \`ci / shell / smoke (macos-latest)\` should now exercise the full postinst path including deep node instrumentation setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)