### PR TITLE
macOS: consolidate the duplicated portable-find-executable detection

### DIFF
--- a/src/usr/share/opentelemetry_shell/agent.sh
+++ b/src/usr/share/opentelemetry_shell/agent.sh
@@ -126,13 +126,10 @@ _otel_list_path_commands() {
   _otel_list_path_executables | _otel_path_2_name
 }
 
-# -executable is a GNU extension; BSD find (macOS) errors out on it, which the redirect below
-# would silently swallow and leave nothing to instrument, so use the portable -perm +111 there
-if \[ "$(\uname -s)" = Darwin ]; then
-  _otel_find_type_executable() { \find "$1" -maxdepth 1 -type "$2" -perm +111 2> /dev/null || \true; }
-else
-  _otel_find_type_executable() { \find "$1" -maxdepth 1 -type "$2" -executable 2> /dev/null || \true; }
-fi
+# $_otel_find_executable_test (set by api.sh) is -executable on Linux and the portable -perm +111
+# on Darwin, where BSD find errors out on -executable; that error would otherwise be silently
+# swallowed by the redirect below and leave nothing to instrument
+_otel_find_type_executable() { \find "$1" -maxdepth 1 -type "$2" $_otel_find_executable_test 2> /dev/null || \true; }
 
 _otel_list_path_executables() {
   \echo "$PATH" | \tr ':' '\n' | while \read dir; do _otel_find_type_executable "$dir" f; _otel_find_type_executable "$dir" l; done

--- a/src/usr/share/opentelemetry_shell/api.sh
+++ b/src/usr/share/opentelemetry_shell/api.sh
@@ -21,6 +21,9 @@ esac
 # basic setup
 if \[ "$(\uname -s)" = Darwin ]; then _otel_shell_home=/usr/local/share/opentelemetry_shell; else _otel_shell_home=/usr/share/opentelemetry_shell; fi
 if \[ "$(\uname -s)" = Darwin ]; then _otel_shell_bin_home=/usr/local/bin; else _otel_shell_bin_home=/usr/bin; fi
+# -executable is a GNU extension, BSD find (macOS) only knows -perm +111; shared by every portable
+# find-executable helper below (and in agent.sh) instead of each repeating its own Darwin branch
+if \[ "$(\uname -s)" = Darwin ]; then _otel_find_executable_test="-perm +111"; else _otel_find_executable_test="-executable"; fi
 if \[ -z "${TMPDIR:-}" ]; then TMPDIR=/tmp; fi
 _otel_shell_pipe_dir="${OTEL_SHELL_PIPE_DIR:-$TMPDIR}"
 _otel_remote_sdk_pipe="${OTEL_REMOTE_SDK_PIPE:-$(\mktemp -u -p "$_otel_shell_pipe_dir" opentelemetry_shell.$$.sdk.pipe.XXXXXXXXXX)}"
@@ -538,16 +541,9 @@ else
   }
 fi
 
-# -executable is a GNU extension, BSD find (macOS) only knows -perm +111
-if \[ "$(\uname -s)" = Darwin ]; then
-  _otel_find_executables() {
-    \find "$1" -perm +111 -iname "$2"
-  }
-else
-  _otel_find_executables() {
-    \find "$1" -executable -iname "$2"
-  }
-fi
+_otel_find_executables() {
+  \find "$1" $_otel_find_executable_test -iname "$2"
+}
 
 _otel_line_join() {
   \sed '/^$/d' | \tr '\n' ' ' | \sed 's/ $//'


### PR DESCRIPTION
## Summary
\`agent.sh\`'s \`_otel_find_type_executable\` and \`api.sh\`'s \`_otel_find_executables\` each independently branched on \`uname -s\` Darwin to pick \`-perm +111\` (BSD find) vs \`-executable\` (GNU find) — same fact, duplicated, with the two definitions having drifted into slightly different shapes since each was fixed independently.

Moves the OS check to a single \`_otel_find_executable_test\` variable set once in \`api.sh\`. Both helpers now just splice it into their \`find\` invocation. Verified under \`dash\` that the unquoted-variable word-splitting works as intended (a zsh test run first gave a false negative, since zsh doesn't word-split unquoted variables by default).

Depends on #3947 (base branch, docker mount path fix).

## Test plan
- [ ] \`dash -n\` on both touched files (done locally)
- [ ] Functional check under \`dash\`: both find invocations produce identical results to the pre-refactor Darwin/Linux branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)