### PR TITLE
macOS: bundle Python deep-injection site-packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -726,7 +726,7 @@ jobs:
           if-no-files-found: error
 
   build-brew:
-    needs: [verify-scripts, merge-http, merge-node-modules]
+    needs: [verify-scripts, merge-http, merge-node-modules, merge-python-site-packages]
     runs-on: ubuntu-slim
     permissions:
       contents: read
@@ -759,6 +759,14 @@ jobs:
         with:
           name: node_modules_${{ inputs.ref }}
           path: src/usr/share/opentelemetry_shell/agent.instrumentation.node
+      # build-python-site-packages already uninstalls every package that ships a compiled .so
+      # (grpcio included) before uploading; this is the exact archive deb/rpm/apk install
+      # unmodified on Linux today, so it's portable to macOS unmodified too, same reasoning as
+      # the node_modules artifact above
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: python_site_packages_${{ inputs.ref }}
+          path: src/usr/share/opentelemetry_shell/agent.instrumentation.python
       - run: |
           cd src/usr/share/opentelemetry_shell/agent.instrumentation.http
           find . -name '*.so' -delete

--- a/meta/debian/postinst
+++ b/meta/debian/postinst
@@ -58,26 +58,19 @@ elif [ "$1" = 'configure' ] || [ "$1" = 'triggered' ] || [ "$1" = 'reconfigure' 
   fi 2>&1 | perl -0777 -pe '' >&2 &
   if type python3; then
     rm -rf "$_otel_shell_home"/agent.instrumentation.python/*/
-    if [ "$(uname -s)" = Darwin ]; then
-      # The prebuilt site-packages are compiled on linux, and the deep-injection requirements
-      # pull grpcio (opentelemetry-exporter-otlp -> -proto-grpc), which ships no pure-python
-      # wheel. Seeding those linux binaries here would leave pip believing grpcio is already
-      # installed while the .so cannot load. So take nothing from the archive (an empty
-      # _python_archived makes the extraction below a no-op) and let the pip install further
-      # down resolve platform-correct wheels from scratch for whichever pythons are present.
-      _python_archived=""
-      _python_versions="$(echo "$PATH" | tr : '\n' | while read -r directory; do find "$directory" -name 'python3.*'; done | grep -v -- - | while read -r executable; do eval "$executable -V"; done | cut -d ' ' -f 2 | cut -d . -f -2 | sort -t. -k2 -n -u)"
+    # build-python-site-packages (the job that produces python_site_packages.tar.xz) uninstalls
+    # every package that ships a compiled .so, including grpcio, before uploading. That's the same
+    # archive deb/rpm/apk already install unmodified on Linux, so reusing it here on macOS is no
+    # new risk: whatever already works without a native grpc extension there works the same way here
+    _python_archived="$(tar -tJf "$_otel_shell_home"/agent.instrumentation.python/python_site_packages.tar.xz 2>/dev/null | cut -d / -f 2 | grep '^3\.' | sort -t. -k2 -n -u)"
+    _python_versions=""
+    if type docker 1>/dev/null 2>/dev/null || [ "$GITHUB_ACTIONS" = true ]; then
+      _python_min_minor="$(printf '%s\n' "$_python_archived" | sort -t. -k2 -n | head -n 1 | cut -d . -f 2)"
+      _python_max_minor="$(grep '^FROM ' "$_otel_shell_home"/agent.instrumentation.python/Dockerfile 2>/dev/null | cut -d ' ' -f 2 | cut -d : -f 2 | cut -d - -f 1 | cut -d . -f 2)"
+      [ -n "$_python_min_minor" ] && [ -n "$_python_max_minor" ] && _python_versions="$(seq "$_python_min_minor" "$_python_max_minor" | while read -r v; do printf '3.%s\n' "$v"; done)" || true
+      [ -n "$_python_versions" ] || _python_versions="$_python_archived"
     else
-      _python_archived="$(tar -tJf "$_otel_shell_home"/agent.instrumentation.python/python_site_packages.tar.xz 2>/dev/null | cut -d / -f 2 | grep '^3\.' | sort -t. -k2 -n -u)"
-      _python_versions=""
-      if type docker 1>/dev/null 2>/dev/null || [ "$GITHUB_ACTIONS" = true ]; then
-        _python_min_minor="$(printf '%s\n' "$_python_archived" | sort -t. -k2 -n | head -n 1 | cut -d . -f 2)"
-        _python_max_minor="$(grep '^FROM ' "$_otel_shell_home"/agent.instrumentation.python/Dockerfile 2>/dev/null | cut -d ' ' -f 2 | cut -d : -f 2 | cut -d - -f 1 | cut -d . -f 2)"
-        [ -n "$_python_min_minor" ] && [ -n "$_python_max_minor" ] && _python_versions="$(seq "$_python_min_minor" "$_python_max_minor" | while read -r v; do printf '3.%s\n' "$v"; done)" || true
-        [ -n "$_python_versions" ] || _python_versions="$_python_archived"
-      else
-        _python_versions="$(echo "$PATH" | tr : '\n' | while read -r directory; do find "$directory" -name 'python3.*'; done | grep -v -- - | while read -r executable; do eval "$executable -V"; done | cut -d ' ' -f 2 | cut -d . -f -2 | sort -t. -k2 -n -u)"
-      fi
+      _python_versions="$(echo "$PATH" | tr : '\n' | while read -r directory; do find "$directory" -name 'python3.*'; done | grep -v -- - | while read -r executable; do eval "$executable -V"; done | cut -d ' ' -f 2 | cut -d . -f -2 | sort -t. -k2 -n -u)"
     fi
     printf '%s\n' "$_python_versions" | while read -r version; do
       [ -n "$version" ] || continue
@@ -99,14 +92,6 @@ elif [ "$1" = 'configure' ] || [ "$1" = 'triggered' ] || [ "$1" = 'reconfigure' 
       done
       [ "$v" -ge 0 ] && [ "3.$v" != "$version" ] && [ ! -d "$_otel_shell_home"/agent.instrumentation.python/"$version" ] && cp -r "$_otel_shell_home"/agent.instrumentation.python/3."$v" "$_otel_shell_home"/agent.instrumentation.python/"$version" || true
     done
-    # nothing was extracted above on macOS, so materialise the version directories the loop
-    # below iterates over; they stay empty and pip populates them from scratch
-    if [ "$(uname -s)" = Darwin ]; then
-      printf '%s\n' "$_python_versions" | while read -r version; do
-        [ -n "$version" ] || continue
-        mkdir -p "$_otel_shell_home"/agent.instrumentation.python/"$version"/site-packages
-      done
-    fi
     ls "$_otel_shell_home"/agent.instrumentation.python | grep -v '.txt$' | grep -v '.py$' | grep -v '.xz$' | grep -v 'Dockerfile$' | while read -r version; do
       venv="$(mktemp -u)"
       if ! type python"$version" || ! eval "python$version" -m venv "$venv"; then

--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.python.sh
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.python.sh
@@ -8,10 +8,10 @@ _otel_inject_python() {
     _otel_python_inject_args "$@" > /dev/null
     local my_code_source="$_otel_python_code_source"
     local python_path="${PYTHONPATH:-}"
-    if _otel_can_inject_python_otel && \[ -d /usr/share/opentelemetry_shell/agent.instrumentation.python/"$version"/site-packages ]; then
+    if _otel_can_inject_python_otel && \[ -d "$_otel_shell_home"/agent.instrumentation.python/"$version"/site-packages ]; then
       unset _otel_python_code_source _otel_python_file _otel_python_module _otel_python_command
       \eval "set -- $(_otel_python_inject_args "$@")"
-      local python_path=/usr/share/opentelemetry_shell/agent.instrumentation.python/"$version"/site-packages/:"$python_path"
+      local python_path="$_otel_shell_home"/agent.instrumentation.python/"$version"/site-packages/:"$python_path"
       if \[ "${OTEL_SHELL_CONFIG_INJECT_DEEP:-FALSE}" = TRUE ]; then
         local command="$1"; shift
         set -- "$command" -c "
@@ -26,10 +26,10 @@ if __name__ == '__main__':
     else
       unset _otel_python_code_source _otel_python_file _otel_python_module _otel_python_command
       \eval "set -- $(_otel_python_inject_args "$@")"
-      local python_path="$(\printf '%s' "$python_path" | \tr ':' '\n' | \grep -vE '^/usr/share/opentelemetry_shell/agent.instrumentation.python/' | \tr '\n' ':')"
+      local python_path="$(\printf '%s' "$python_path" | \tr ':' '\n' | \grep -vE '^'"$_otel_shell_home"'/agent.instrumentation.python/' | \tr '\n' ':')"
     fi
     if \[ "${my_code_source:-}" = stdin ]; then
-      { \cat /usr/share/opentelemetry_shell/agent.instrumentation.python/deep.py; \cat; } | OTEL_SHELL_COMMANDLINE_OVERRIDE="$cmdline" OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="0" OTEL_SHELL_AUTO_INJECTED=TRUE PYTHONPATH="$python_path" OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 _otel_call "$@" || local exit_code="$?"
+      { \cat "$_otel_shell_home"/agent.instrumentation.python/deep.py; \cat; } | OTEL_SHELL_COMMANDLINE_OVERRIDE="$cmdline" OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="0" OTEL_SHELL_AUTO_INJECTED=TRUE PYTHONPATH="$python_path" OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 _otel_call "$@" || local exit_code="$?"
     else
       OTEL_SHELL_COMMANDLINE_OVERRIDE="$cmdline" OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="0" OTEL_SHELL_AUTO_INJECTED=TRUE PYTHONPATH="$python_path" OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 _otel_call "$@" || local exit_code="$?"
     fi
@@ -58,7 +58,7 @@ _otel_inject_opentelemetry_instrument() {
     \eval "set -- $(_otel_python_inject_args "$@")"
     if \[ "${_otel_python_code_source:-}" = stdin ]; then
       unset _otel_python_code_source
-      { \cat /usr/share/opentelemetry_shell/agent.instrumentation.python/deep.py; \cat; } | OTEL_SHELL_COMMANDLINE_OVERRIDE="$cmdline" OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="0" OTEL_SHELL_AUTO_INJECTED=TRUE OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 _otel_call "$@"
+      { \cat "$_otel_shell_home"/agent.instrumentation.python/deep.py; \cat; } | OTEL_SHELL_COMMANDLINE_OVERRIDE="$cmdline" OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="0" OTEL_SHELL_AUTO_INJECTED=TRUE OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 _otel_call "$@"
     else
       OTEL_SHELL_COMMANDLINE_OVERRIDE="$cmdline" OTEL_SHELL_COMMANDLINE_OVERRIDE_SIGNATURE="0" OTEL_SHELL_AUTO_INJECTED=TRUE OTEL_BSP_MAX_EXPORT_BATCH_SIZE=1 _otel_call "$@"
     fi
@@ -86,7 +86,7 @@ _otel_python_inject_args() {
       _otel_escape_arg "$arg"
       \echo -n ' '
       local arg="$1"; shift
-      _otel_escape_arg "$(\cat /usr/share/opentelemetry_shell/agent.instrumentation.python/deep.py)
+      _otel_escape_arg "$(\cat "$_otel_shell_home"/agent.instrumentation.python/deep.py)
 $arg"
       _otel_python_command="$arg"
       _otel_python_code_source=cmdline
@@ -94,13 +94,13 @@ $arg"
       _otel_escape_args -c
       \echo -n ' '
       local arg="$1"; shift
-      _otel_escape_arg "$(\cat /usr/share/opentelemetry_shell/agent.instrumentation.python/deep.py)
+      _otel_escape_arg "$(\cat "$_otel_shell_home"/agent.instrumentation.python/deep.py)
 import runpy # SKIP_DEPENDENCY_CHECK
 runpy.run_module('$arg', run_name='__main__')"
       _otel_python_module="$arg"
       _otel_python_code_source=module
     elif \[ -f "$arg" ]; then
-      _otel_escape_args -c "$(\cat /usr/share/opentelemetry_shell/agent.instrumentation.python/deep.py)
+      _otel_escape_args -c "$(\cat "$_otel_shell_home"/agent.instrumentation.python/deep.py)
 import sys, os # SKIP_DEPENDENCY_CHECK
 sys.path.insert(0, os.path.abspath(os.path.dirname('$arg'))) # SKIP_DEPENDENCY_CHECK
 with open('$arg', 'r') as file: # SKIP_DEPENDENCY_CHECK


### PR DESCRIPTION
## Summary
The macOS branch of postinst's python handling assumed the archived \`python_site_packages.tar.xz\` would contain grpcio's compiled \`.so\` and skipped seeding from it entirely, rebuilding from scratch via pip on every install instead. That assumption was wrong: \`build-python-site-packages\` already uninstalls every package that ships a compiled \`.so\`, grpcio included, before uploading the artifact — true today, for the artifact deb/rpm/apk already install unmodified on Linux. The archive was pure Python already; nothing macOS-specific was needed.

Removes the Darwin branch and its now-unnecessary "materialize empty version directories" follow-up, leaving one shared code path. \`build-brew\` downloads \`python_site_packages_*\` into the tarball the same way deb/rpm/apk do, and \`agent.instrumentation.python.sh\`'s 8 hardcoded path references switch to \`"\$_otel_shell_home"\`.

With this, all three deep-injection languages (Java #3945, Node #3944/#3949, Python) plus the SDK venv are bundled and wired through the same postinst path on macOS.

Depends on #3949 (base branch, postinst wiring).

## Test plan
- [ ] \`sh -n\`/\`dash -n\` on all touched files (done locally)
- [ ] CI: \`ci / shell / smoke (macos-latest)\` should exercise deep python instrumentation setup end-to-end for the first time

🤖 Generated with [Claude Code](https://claude.com/claude-code)