### PR TITLE
Treat OTEL_PROPAGATORS as a list and ignore unknown values

### DIFF
--- a/src/usr/share/opentelemetry_shell/sdk.py
+++ b/src/usr/share/opentelemetry_shell/sdk.py
@@ -152,7 +152,13 @@ def handle(scope, version, command, arguments):
         propagators = os.environ.get('OTEL_PROPAGATORS', 'tracecontext')
         sampling_strategy = os.environ.get('OTEL_TRACES_SAMPLER', 'parentbased_always_on')
         sampling_strategy_arg = os.environ.get('OTEL_TRACES_SAMPLER_ARG', '1.0')
-        for propagator in dict.fromkeys(propagator.strip().lower() for propagator in propagators.split(',') if propagator.strip()):
+        # careful: actions/instrument/job/inject_and_init.sh greps this file for module-loading keywords to pre-warm its SDK factory, so those substrings must not appear in ordinary statements
+        seen_propagators = []
+        for propagator in propagators.split(','):
+            propagator = propagator.strip().lower()
+            if not propagator or propagator in seen_propagators:
+                continue
+            seen_propagators.append(propagator)
             if propagator not in ('tracecontext', 'none'):
                 print('Unsupported propagator, ignoring: ' + propagator, file=sys.stderr)
         if traces_exporters:

--- a/src/usr/share/opentelemetry_shell/sdk.py
+++ b/src/usr/share/opentelemetry_shell/sdk.py
@@ -149,11 +149,12 @@ def handle(scope, version, command, arguments):
         from opentelemetry.sdk.trace.export import SimpleSpanProcessor, BatchSpanProcessor, ConsoleSpanExporter
         from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
         traces_exporters = os.environ.get('OTEL_TRACES_EXPORTER', 'otlp')
-        propagator = os.environ.get('OTEL_PROPAGATORS', 'tracecontext')
+        propagators = os.environ.get('OTEL_PROPAGATORS', 'tracecontext')
         sampling_strategy = os.environ.get('OTEL_TRACES_SAMPLER', 'parentbased_always_on')
         sampling_strategy_arg = os.environ.get('OTEL_TRACES_SAMPLER_ARG', '1.0')
-        if propagator != 'tracecontext':
-            raise Exception('Unsupported propagator: ' + propagator)
+        for propagator in dict.fromkeys(propagator.strip().lower() for propagator in propagators.split(',') if propagator.strip()):
+            if propagator not in ('tracecontext', 'none'):
+                print('Unsupported propagator, ignoring: ' + propagator, file=sys.stderr)
         if traces_exporters:
             sampler = None
             if sampling_strategy == 'always_on':


### PR DESCRIPTION
OTEL_PROPAGATORS is specified as a comma-separated list whose default value is "tracecontext,baggage". The SDK compared it against the single literal "tracecontext" and raised otherwise, so any spec-conformant configuration (including the specified default) made every SPAN_* command fail. Because initialized_traces is only set at the end of the initialization block, the exception was re-raised for every subsequent command rather than once.

Parse the value as a list, deduplicate it, compare case-insensitively, and warn-and-ignore unrecognized entries as the environment variable specification requires. Thoth still only implements W3C Trace Context; this only stops it from failing when other propagators are configured.

Refs #4196