### PR TITLE
Do not export an empty TRACEPARENT

### DIFF
--- a/src/usr/share/opentelemetry_shell/api.sh
+++ b/src/usr/share/opentelemetry_shell/api.sh
@@ -257,8 +257,9 @@ otel_span_traceparent() {
 
 otel_span_activate() {
   local span_handle="$1"
+  local traceparent="$(otel_span_traceparent "$span_handle")"
   \export TRACEPARENT_STACK="${TRACEPARENT:-}/${TRACEPARENT_STACK:-}"
-  \export TRACEPARENT="$(otel_span_traceparent "$span_handle")"
+  if \[ -n "$traceparent" ]; then \export TRACEPARENT="$traceparent"; fi
   if \[ -z "${TRACESTATE:-}" ]; then \export TRACESTATE=""; fi
 }
 


### PR DESCRIPTION
otel_span_activate exported the injected traceparent unconditionally. When the SDK yields no traceparent, for example because traces are disabled and the span context is invalid, this exported TRACEPARENT as an empty string rather than leaving it unset.

Consumers that distinguish an absent carrier field from an empty one then see a present but unusable value. It also clobbered any incoming trace context in that case, where passing it through unchanged is the correct behavior.

Leave the variable untouched when there is nothing to inject. The activation stack is still pushed, so deactivation is unaffected, and TRACEPARENT is never newly unset by this change, so existing readers that dereference it without a default are unaffected.

Refs #4196