### PR TITLE
Update dependency net.bytebuddy:byte-buddy to v1.18.13-jdk5 (#4194)

### DIFF
--- a/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
+++ b/src/usr/share/opentelemetry_shell/agent.instrumentation.java/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>net.bytebuddy</groupId>
       <artifactId>byte-buddy</artifactId>
-      <version>1.18.12-jdk5</version>
+      <version>1.18.13-jdk5</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Automated backport of commit e537599558ac1c470781b771383930b2d129ea2a